### PR TITLE
List page search (very basic rn)

### DIFF
--- a/src/html/list.html
+++ b/src/html/list.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -16,7 +16,12 @@
         </button>
       </header>
       <div class="search-container">
-        <input type="text" placeholder="Search..." class="search-bar" id="search-bar"/>
+        <input
+          type="text"
+          placeholder="Search..."
+          class="search-bar"
+          id="search-bar"
+        />
       </div>
       <div class="add-button-container">
         <button class="new-journal-button">New Journal</button>

--- a/src/html/list.html
+++ b/src/html/list.html
@@ -18,7 +18,7 @@
       <div class="search-container">
         <input
           type="text"
-          placeholder="Search..."
+          placeholder="Search... (type # to search by tag)"
           class="search-bar"
           id="search-bar"
         />

--- a/src/html/list.html
+++ b/src/html/list.html
@@ -16,7 +16,7 @@
         </button>
       </header>
       <div class="search-container">
-        <input type="text" placeholder="Search..." class="search-bar" />
+        <input type="text" placeholder="Search..." class="search-bar" id="search-bar"/>
       </div>
       <div class="add-button-container">
         <button class="new-journal-button">New Journal</button>

--- a/src/html/list.html
+++ b/src/html/list.html
@@ -18,7 +18,7 @@
       <div class="search-container">
         <input
           type="text"
-          placeholder="Search... (type # to search by tag)"
+          placeholder="Search... (type # if search by tag)"
           class="search-bar"
           id="search-bar"
         />

--- a/src/scripts/list.js
+++ b/src/scripts/list.js
@@ -1,23 +1,6 @@
-const rawData = [
-  {
-    "timestamp": "1716097247973",
-    "title": "This da bomb",
-    "tags": ["GPT", "IS", "GOAT"],
-    "delta": { "ops": [{ "insert": "\n" }] }
-  },
-  {
-    "timestamp": "1723097247973",
-    "title": "This da bomb",
-    "tags": [],
-    "delta": { "ops": [{ "insert": "\n" }] }
-  }
-];
+
 //Store the data into localStorage before staring all the things.
 let journalList = getJournalList();
-if (journalList.length === 0) {
-  saveJournal(rawData);
-  journalList = rawData;
-}
 
 document.addEventListener("DOMContentLoaded", init());
 

--- a/src/scripts/list.js
+++ b/src/scripts/list.js
@@ -5,15 +5,15 @@ document.addEventListener("DOMContentLoaded", init());
 
 function init() {
   displayList(journalList);
+  setUpSearch();
 }
 
-function displayList (journalList){
-    //Iterate through list and append them to HTML
-    journalList.forEach((item) => {
-        createListItem(item);
-    });
+function displayList(list) {
+  //Iterate through list and append them to HTML
+  list.forEach((item) => {
+    createListItem(item);
+  });
 }
-
 
 function createListItem(item) {
   //Get the essential elements
@@ -28,7 +28,7 @@ function createListItem(item) {
   const details = document.createElement("div");
   details.style.fontSize = "small";
 
-//   Get and set timestamp
+  //Get and set timestamp
   const timestamp = new Date(parseInt(item.timestamp)).toLocaleString();
   const timestampText = document.createElement("div");
   timestampText.textContent = `Timestamp: ${timestamp}`;
@@ -43,7 +43,7 @@ function createListItem(item) {
     tagElement.textContent = tag;
     tagElement.className = "tag";
     tagElement.onclick = () => {
-    // Event triggered when clicking into tag. Future feature for filter search
+      // Event triggered when clicking into tag. Future feature for filter search
     };
     tagsContainer.appendChild(tagElement);
     tagsContainer.appendChild(document.createTextNode(" ")); // Add space between tags
@@ -58,7 +58,7 @@ function createListItem(item) {
   deleteButton.className = "delete-button";
   deleteButton.style.display = "none";
 
-// EventListener: When clicking delete, delete from page and LocalStorage
+  // EventListener: When clicking delete, delete from page and LocalStorage
   deleteButton.onclick = () => {
     listItem.remove();
     deleteJournal(item.timestamp);
@@ -72,23 +72,57 @@ function createListItem(item) {
     deleteButton.style.display = "none";
   };
 
-//   Append the entire list item into the list
+  //   Append the entire list item into the list
   itemList.appendChild(listItem);
 }
 
 function getJournalList() {
-    if (!localStorage.getItem("GarlicNotes")) {
-        return [];
-    } else {
-        return JSON.parse(localStorage.getItem("GarlicNotes"));
-    }
+  if (!localStorage.getItem("GarlicNotes")) {
+    return [];
+  } else {
+    return JSON.parse(localStorage.getItem("GarlicNotes"));
+  }
 }
 
 function deleteJournal(timestamp) {
-    journalList = journalList.filter(entry => entry.timestamp != timestamp);
-    saveJournal(journalList);
+  journalList = journalList.filter(entry => entry.timestamp != timestamp);
+  saveJournal(journalList);
 }
 
 function saveJournal(journalList) {
-    localStorage.setItem("GarlicNotes", JSON.stringify(journalList));
+  localStorage.setItem("GarlicNotes", JSON.stringify(journalList));
+}
+
+function getMatchingEntries(list, query) {
+  let matchingEntriesByTitle = [];
+  let matchingEntriesByContent = [];
+  query = query.toLowerCase();
+  // Prioritize entries matching on title before matching on content.
+  list.forEach((entry) => {
+    if (entry.title.toLowerCase().includes(query)) {
+      matchingEntriesByTitle.push(entry);
+    } else if (getTextFromDelta(entry.delta).toLowerCase().includes(query)) {
+      matchingEntriesByContent.push(entry);
+    }
+  });
+  return matchingEntriesByTitle.concat(matchingEntriesByContent);
+}
+
+function getTextFromDelta(delta) {
+  // Include each string in insert operations within a Quill Delta
+  let text = '';
+  delta.ops.forEach((op) => {
+    text += op.insert;
+  });
+  return text;
+}
+
+function setUpSearch() {
+  const searchBar = document.getElementById("search-bar");
+  // EventListener: After typing, filter items to those matching search
+  searchBar.oninput = () => {
+    const itemList = document.getElementById("item-list");
+    itemList.replaceChildren(); // Empty item list
+    displayList(getMatchingEntries(journalList, searchBar.value));
+  };
 }

--- a/src/scripts/list.js
+++ b/src/scripts/list.js
@@ -21,7 +21,6 @@ function createListItem(item) {
   const listItem = document.createElement("li");
   const title = document.createElement("div");
 
-
   title.textContent = item.title;
   listItem.appendChild(title);
 
@@ -85,7 +84,7 @@ function getJournalList() {
 }
 
 function deleteJournal(timestamp) {
-  journalList = journalList.filter(entry => entry.timestamp != timestamp);
+  journalList = journalList.filter((entry) => entry.timestamp != timestamp);
   saveJournal(journalList);
 }
 
@@ -110,7 +109,7 @@ function getMatchingEntries(list, query) {
 
 function getTextFromDelta(delta) {
   // Include each string in insert operations within a Quill Delta
-  let text = '';
+  let text = "";
   delta.ops.forEach((op) => {
     text += op.insert;
   });

--- a/src/scripts/list.js
+++ b/src/scripts/list.js
@@ -1,5 +1,23 @@
+const rawData = [
+  {
+    "timestamp": "1716097247973",
+    "title": "This da bomb",
+    "tags": ["GPT", "IS", "GOAT"],
+    "delta": { "ops": [{ "insert": "\n" }] }
+  },
+  {
+    "timestamp": "1723097247973",
+    "title": "This da bomb",
+    "tags": [],
+    "delta": { "ops": [{ "insert": "\n" }] }
+  }
+];
 //Store the data into localStorage before staring all the things.
 let journalList = getJournalList();
+if (journalList.length === 0) {
+  saveJournal(rawData);
+  journalList = rawData;
+}
 
 document.addEventListener("DOMContentLoaded", init());
 
@@ -95,6 +113,8 @@ function saveJournal(journalList) {
 function getMatchingEntries(list, query) {
   let matchingEntriesByTitle = [];
   let matchingEntriesByContent = [];
+  let matchingEntriesByTags = [];
+  let matchingEntriesByTimestamp = [];
   query = query.toLowerCase();
   // Prioritize entries matching on title before matching on content.
   list.forEach((entry) => {
@@ -102,9 +122,17 @@ function getMatchingEntries(list, query) {
       matchingEntriesByTitle.push(entry);
     } else if (getTextFromDelta(entry.delta).toLowerCase().includes(query)) {
       matchingEntriesByContent.push(entry);
-    }
+    } else if (new Date(parseInt(entry.timestamp)).toLocaleString().toLowerCase().includes(query)) {
+      matchingEntriesByTimestamp.push(entry);
+    } else {
+      // Check if any tag in the entry matches the query
+      const matchingTags = entry.tags.filter(tag => tag.toLowerCase().includes(query));
+      if (matchingTags.length > 0) {
+        matchingEntriesByTags.push(entry);
+      }
+  }
   });
-  return matchingEntriesByTitle.concat(matchingEntriesByContent);
+  return matchingEntriesByTitle.concat(matchingEntriesByContent, matchingEntriesByTimestamp, matchingEntriesByTags);
 }
 
 function getTextFromDelta(delta) {

--- a/src/scripts/list.js
+++ b/src/scripts/list.js
@@ -111,11 +111,17 @@ function saveJournal(journalList) {
 }
 
 function getMatchingEntries(list, query) {
+  query = query.toLowerCase();
+
+  if (query.startsWith("#")) {
+    // type # to search by tags
+    return searchByTags(list, query.slice(1));
+  }
+
   let matchingEntriesByTitle = [];
   let matchingEntriesByContent = [];
-  let matchingEntriesByTags = [];
   let matchingEntriesByTimestamp = [];
-  query = query.toLowerCase();
+
   // Prioritize entries matching on title before matching on content.
   list.forEach((entry) => {
     if (entry.title.toLowerCase().includes(query)) {
@@ -124,15 +130,10 @@ function getMatchingEntries(list, query) {
       matchingEntriesByContent.push(entry);
     } else if (new Date(parseInt(entry.timestamp)).toLocaleString().toLowerCase().includes(query)) {
       matchingEntriesByTimestamp.push(entry);
-    } else {
-      // Check if any tag in the entry matches the query
-      const matchingTags = entry.tags.filter(tag => tag.toLowerCase().includes(query));
-      if (matchingTags.length > 0) {
-        matchingEntriesByTags.push(entry);
-      }
-  }
+    }
   });
-  return matchingEntriesByTitle.concat(matchingEntriesByContent, matchingEntriesByTimestamp, matchingEntriesByTags);
+
+  return matchingEntriesByTitle.concat(matchingEntriesByContent, matchingEntriesByTimestamp);
 }
 
 function getTextFromDelta(delta) {
@@ -144,6 +145,13 @@ function getTextFromDelta(delta) {
   return text;
 }
 
+function searchByTags(list, query) {
+  query = query.toLowerCase();
+  return list.filter((entry) => {
+    return entry.tags.some(tag => tag.toLowerCase().includes(query));
+  });
+}
+
 function setUpSearch() {
   const searchBar = document.getElementById("search-bar");
   // EventListener: After typing, filter items to those matching search
@@ -153,3 +161,4 @@ function setUpSearch() {
     displayList(getMatchingEntries(journalList, searchBar.value));
   };
 }
+


### PR DESCRIPTION
`getMatchingEntries`:
given a list of entries (so can be after filters are applied) and a query, returns matching entries where those with matching text in the title come before those matching text in the content
`getTextFromDelta`:
given a delta, returns the text in that delta (right now `\n` is included as a character, not sure if we should keep it this way or strip it. because logically, people aren't going to try to search by words split across different paragraphs). this iterates thru each operation in `ops` to get the text. If I were to get the text thru Quill's API I would have to instantiate a Quill object which sets up the editor too, and for each entry, setContent then getText, which I think is heavier.
`setUpSearch`:
attaches an event listener to the search bar that makes it so only matching entries are displayed

I didn't name any function `searchJournal` yet because I feel like it would include code to filter for time period and tags.