### PR TITLE
Fix broken unit tests on list-page

### DIFF
--- a/src/scripts/list.js
+++ b/src/scripts/list.js
@@ -51,14 +51,13 @@ function init() {
       }, 0);
     }
   };
+  document.getElementById("sort-name").addEventListener("click", () => {
+    sortByCategory("name");
+  });
+  document.getElementById("sort-timestamp").addEventListener("click", () => {
+    sortByCategory("timestamp");
+  });
 }
-
-document.getElementById("sort-name").addEventListener("click", () => {
-  sortByCategory("name");
-});
-document.getElementById("sort-timestamp").addEventListener("click", () => {
-  sortByCategory("timestamp");
-});
 
 /**
  * Sorts the journal list by the specified category.


### PR DESCRIPTION
fixes #75 by moving DOM-related code that triggers once and wasn't in `init`, into `init`
- idk where to put a PSA for people who are writing DOM-related calls that they put globally, to move it into `init`