### PR TITLE
Fix testing GitHub actions

### DIFF
--- a/.github/workflows/jest.e2e.cjs
+++ b/.github/workflows/jest.e2e.cjs
@@ -1,4 +1,5 @@
 module.exports = {
     preset: 'jest-puppeteer',
-    testMatch: ['**/__tests__/e2e.test.js']
+    testMatch: ['**/tests/e2e.test.js'],
+    rootDir: "../../"
   };

--- a/.github/workflows/jest.unit.cjs
+++ b/.github/workflows/jest.unit.cjs
@@ -1,4 +1,5 @@
 module.exports = {
     testEnvironment: 'node',
-    testMatch: ['**/__tests__/unitTests.test.js'],
+    testMatch: ["**/tests/unitTests.test.js"],
+    rootDir: "../../"
   };

--- a/jest-puppeteer.cjs
+++ b/jest-puppeteer.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+    launch: {
+      headless: true,
+      slowMo: 25
+    }
+  }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-    launch: {
-      headless: true,
-      slowMo: 25
-    }
-  }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "quill": "^2.0.2"
   },
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config .github/workflows/jest.unit.cjs",
     "test:e2e": "jest --maxWorkers=1 --config .github/workflows/jest.e2e.cjs"
   },
   "type": "module",

--- a/src/tests/e2e.test.js
+++ b/src/tests/e2e.test.js
@@ -3,4 +3,7 @@ describe('Basic user flow for Website', () => {
     beforeAll(async () => {
       await page.goto('http://127.0.0.1:5501/src/html/list.html');
     });
+    test("dummy", () => {
+      
+    });
 });


### PR DESCRIPTION
- fix unit test config to only run unit tests on package.json
- create dummy test on e2e.test.js so that tests actually run
- correctly match tests in test configs by going to the real root directory and correcting tests folder on jest.e2e.cjs and jest.unit.cjs
- rename puppeteer config to be .cjs on jest-puppeteer.cjs

Fixes #86
This gets all tests to execute successfully.