### PR TITLE
Updating list-page branch

### DIFF
--- a/.github/workflows/Lint&Doc.yml
+++ b/.github/workflows/Lint&Doc.yml
@@ -16,20 +16,17 @@ jobs:
         uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write **/*.{js,md,html,css}
-          only_changed: True
-          github_token: ${{ secrets.GH_PAT }}
+          only_changed: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_message: "Code Formatted by GitHub Action"
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          git push origin HEAD:${{ github.ref_name }}
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "Code Formatted by GitHub Action"
+          committer_name: GitHub Actions
+          committer_email: actions@github.com
+          push: origin documentation:documentation
 
   JSDoc-generation:
     needs: prettier-linting
@@ -38,21 +35,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build
+      - name: Build JSDoc
         uses: andstor/jsdoc-action@v1
         with:
           source_dir: ./src/scripts
           output_dir: ./docs
 
-      - name: Configure Git
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-
-      - name: Commit and push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          git add .
-          git commit -m "JSDoc updated by GitHub Action [ci skip]" --author "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          git push origin HEAD:${{ github.ref_name }}
+      - name: Commit and push JSDoc changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "JSDoc updated by GitHub Action"
+          committer_name: GitHub Actions
+          committer_email: actions@github.com
+          push: origin documentation:documentation

--- a/.github/workflows/Lint&Doc.yml
+++ b/.github/workflows/Lint&Doc.yml
@@ -3,23 +3,34 @@ name: Prettier Linting & JS Doc Generation
 on:
   push:
     branches:
-        - main
+      - main
 
 jobs:
   prettier-linting:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-  
-        - name: Prettify code
-          uses: creyD/prettier_action@v4.3
-          with:
-            prettier_options: --write **/*.{js,md,html,css}
-            only_changed: True
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            commit_message: "Code Formatted by GitHub Action"
-  
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          prettier_options: --write **/*.{js,md,html,css}
+          only_changed: True
+          github_token: ${{ secrets.GH_PAT }}
+          commit_message: "Code Formatted by GitHub Action"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          git push origin HEAD:${{ github.ref_name }}
+
   JSDoc-generation:
     needs: prettier-linting
     runs-on: ubuntu-latest
@@ -33,10 +44,17 @@ jobs:
           source_dir: ./src/scripts
           output_dir: ./docs
 
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v9
         with:
           message: JSDoc updated by GitHub Action
           committer_name: GitHub Actions
           committer_email: actions@github.com
-          push: origin HEAD:${{github.ref_name}}
+          push: origin HEAD:${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/Lint&Doc.yml
+++ b/.github/workflows/Lint&Doc.yml
@@ -3,31 +3,23 @@ name: Prettier Linting & JS Doc Generation
 on:
   push:
     branches:
-      - main
+        - main-doc
 
 jobs:
   prettier-linting:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.3
-        with:
-          prettier_options: --write **/*.{js,md,html,css}
-          only_changed: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_message: "Code Formatted by GitHub Action"
-
-      - name: Push changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: "Code Formatted by GitHub Action"
-          committer_name: GitHub Actions
-          committer_email: actions@github.com
-          push: origin documentation:documentation
-
+        - name: Checkout
+          uses: actions/checkout@v4
+  
+        - name: Prettify code
+          uses: creyD/prettier_action@v4.3
+          with:
+            prettier_options: --write **/*.{js,md,html,css}
+            only_changed: True
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            commit_message: "Code Formatted by GitHub Action"
+  
   JSDoc-generation:
     needs: prettier-linting
     runs-on: ubuntu-latest
@@ -35,16 +27,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build JSDoc
+      - name: Build
         uses: andstor/jsdoc-action@v1
         with:
           source_dir: ./src/scripts
           output_dir: ./docs
 
-      - name: Commit and push JSDoc changes
+      - name: Commit and push changes
         uses: EndBug/add-and-commit@v9
         with:
-          message: "JSDoc updated by GitHub Action"
+          message: JSDoc updated by GitHub Action
           committer_name: GitHub Actions
           committer_email: actions@github.com
-          push: origin documentation:documentation
+          push: origin HEAD:${{github.ref_name}}

--- a/.github/workflows/Lint&Doc.yml
+++ b/.github/workflows/Lint&Doc.yml
@@ -50,11 +50,9 @@ jobs:
           git config user.email "actions@github.com"
 
       - name: Commit and push changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: JSDoc updated by GitHub Action
-          committer_name: GitHub Actions
-          committer_email: actions@github.com
-          push: origin HEAD:${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          git add .
+          git commit -m "JSDoc updated by GitHub Action [ci skip]" --author "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          git push origin HEAD:${{ github.ref_name }}


### PR DESCRIPTION
This is done so that list-page will be the most updated branch and stay ahead of main. All changes made on sub-branches will face reduced merge conflicts when shipping later to main. 